### PR TITLE
Add missing precinct column header

### DIFF
--- a/2018/counties/20181106__ky__general__franklin__precinct.csv
+++ b/2018/counties/20181106__ky__general__franklin__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Franklin,AB,Ballots Cast,,,,1214
 Franklin,A101,Ballots Cast,,,,732
 Franklin,A102A,Ballots Cast,,,,432

--- a/2019/20191105__ky__general__anderson__precinct.csv
+++ b/2019/20191105__ky__general__anderson__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Anderson,AB,Ballots Cast,,,,412.0
 Anderson,A101,Ballots Cast,,,,565.0
 Anderson,A102,Ballots Cast,,,,582.0

--- a/2019/20191105__ky__general__bracken__precinct.csv
+++ b/2019/20191105__ky__general__bracken__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Bracken,AB,Ballots Cast,,,,204.0
 Bracken,A101,Ballots Cast,,,,356.0
 Bracken,B101,Ballots Cast,,,,286.0

--- a/2019/20191105__ky__general__carlisle__precinct.csv
+++ b/2019/20191105__ky__general__carlisle__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Carlisle,AB,Ballots Cast,,,,93.0
 Carlisle,A101,Ballots Cast,,,,273.0
 Carlisle,A102,Ballots Cast,,,,277.0

--- a/2019/20191105__ky__general__carter__precinct.csv
+++ b/2019/20191105__ky__general__carter__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Carter,AB,Ballots Cast,,,,417.0
 Carter,A101,Ballots Cast,,,,430.0
 Carter,A102,Ballots Cast,,,,189.0

--- a/2019/20191105__ky__general__edmonson__precinct.csv
+++ b/2019/20191105__ky__general__edmonson__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Edmonson,AB,Ballots Cast,,,,191.0
 Edmonson,A101,Ballots Cast,,,,254.0
 Edmonson,A102,Ballots Cast,,,,483.0

--- a/2019/20191105__ky__general__franklin__precinct.csv
+++ b/2019/20191105__ky__general__franklin__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Franklin,AB,Ballots Cast,,,,955.0
 Franklin,A101,Ballots Cast,,,,737.0
 Franklin,A102A,Ballots Cast,,,,426.0

--- a/2019/20191105__ky__general__harrison__precinct.csv
+++ b/2019/20191105__ky__general__harrison__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Harrison,AB4,Ballots Cast,,,,173.0
 Harrison,AB6,Ballots Cast,,,,113.0
 Harrison,A101,Ballots Cast,,,,344.0

--- a/2019/20191105__ky__general__mason__precinct.csv
+++ b/2019/20191105__ky__general__mason__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Mason,AB,Ballots Cast,,,,216.0
 Mason,A101,Ballots Cast,,,,271.0
 Mason,A103,Ballots Cast,,,,339.0

--- a/2019/20191105__ky__general__mercer__precinct.csv
+++ b/2019/20191105__ky__general__mercer__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Mercer,AB,Ballots Cast,,,,385.0
 Mercer,A101,Ballots Cast,,,,872.0
 Mercer,A102,Ballots Cast,,,,125.0

--- a/2019/20191105__ky__general__metcalfe__precinct.csv
+++ b/2019/20191105__ky__general__metcalfe__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Metcalfe,AB,Ballots Cast,,,,176.0
 Metcalfe,A101,Ballots Cast,,,,593.0
 Metcalfe,A102,Ballots Cast,,,,490.0

--- a/2019/20191105__ky__general__nicholas__precinct.csv
+++ b/2019/20191105__ky__general__nicholas__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Nicholas,AB,Ballots Cast,,,,199.0
 Nicholas,A101,Ballots Cast,,,,379.0
 Nicholas,B101,Ballots Cast,,,,438.0

--- a/2019/20191105__ky__general__oldham__precinct.csv
+++ b/2019/20191105__ky__general__oldham__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Oldham,AB,Ballots Cast,,,,1141.0
 Oldham,A101,Ballots Cast,,,,1070.0
 Oldham,A103,Ballots Cast,,,,1092.0

--- a/2019/20191105__ky__general__russell__precinct.csv
+++ b/2019/20191105__ky__general__russell__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Russell,AB,Ballots Cast,,,,322.0
 Russell,A101,Ballots Cast,,,,336.0
 Russell,A102,Ballots Cast,,,,339.0

--- a/2019/20191105__ky__general__spencer__precinct.csv
+++ b/2019/20191105__ky__general__spencer__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Spencer,AB2,Ballots Cast,,,,55.0
 Spencer,AB4,Ballots Cast,,,,174.0
 Spencer,A101,Ballots Cast,,,,1204.0

--- a/2019/20191105__ky__general__taylor__precinct.csv
+++ b/2019/20191105__ky__general__taylor__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Taylor,AB,Ballots Cast,,,,389.0
 Taylor,A101,Ballots Cast,,,,256.0
 Taylor,A102,Ballots Cast,,,,325.0

--- a/2019/20191105__ky__general__union__precinct.csv
+++ b/2019/20191105__ky__general__union__precinct.csv
@@ -1,4 +1,4 @@
-county,office,district,party,candidate,votes
+county,precinct,office,district,party,candidate,votes
 Union,AB,Ballots Cast,,,,197.0
 Union,A101,Ballots Cast,,,,408.0
 Union,A103,Ballots Cast,,,,266.0


### PR DESCRIPTION
Several files contained data with an additional column compared to the header.  It turns out that the `precinct` column header was missing.