### PR TITLE
Remove newline characters from entries

### DIFF
--- a/2018/counties/20181106__ky__general__marshall__precinct.csv
+++ b/2018/counties/20181106__ky__general__marshall__precinct.csv
@@ -11,18 +11,12 @@ Danny Carroll,State Senate,2,REP,Marshall,Absentee Mail-In,94
 Julie Tennyson,State Senate,2,DEM,Marshall,Absentee Mail-In,54
 Chris Freeland,State Representative,6,REP,Marshall,Absentee Mail-In,87
 Linda Story Edwards,State Representative,6,DEM,Marshall,Absentee Mail-In,60
-James R Comer,U.S. House,1,REP,Marshall,"A101 South
-Benton",388
-Paul Walker,U.S. House,1,DEM,Marshall,"A101 South
-Benton",228
-Danny Carroll,State Senate,2,REP,Marshall,"A101 South
-Benton",383
-Julie Tennyson,State Senate,2,DEM,Marshall,"A101 South
-Benton",247
-Chris Freeland,State Representative,6,REP,Marshall,"A101 South
-Benton",383
-Linda Story Edwards,State Representative,6,DEM,Marshall,"A101 South
-Benton",254
+James R Comer,U.S. House,1,REP,Marshall,"A101 South Benton",388
+Paul Walker,U.S. House,1,DEM,Marshall,"A101 South Benton",228
+Danny Carroll,State Senate,2,REP,Marshall,"A101 South Benton",383
+Julie Tennyson,State Senate,2,DEM,Marshall,"A101 South Benton",247
+Chris Freeland,State Representative,6,REP,Marshall,"A101 South Benton",383
+Linda Story Edwards,State Representative,6,DEM,Marshall,"A101 South Benton",254
 James R Comer,U.S. House,1,REP,Marshall,A102 Ross,460
 Paul Walker,U.S. House,1,DEM,Marshall,A102 Ross,212
 Danny Carroll,State Senate,2,REP,Marshall,A102 Ross,457
@@ -35,18 +29,12 @@ Danny Carroll,State Senate,2,REP,Marshall,A103 Olive,377
 Julie Tennyson,State Senate,2,DEM,Marshall,A103 Olive,289
 Chris Freeland,State Representative,6,REP,Marshall,A103 Olive,361
 Linda Story Edwards,State Representative,6,DEM,Marshall,A103 Olive,305
-James R Comer,U.S. House,1,REP,Marshall,"A104 South
-Marshall",310
-Paul Walker,U.S. House,1,DEM,Marshall,"A104 South
-Marshall",139
-Danny Carroll,State Senate,2,REP,Marshall,"A104 South
-Marshall",336
-Julie Tennyson,State Senate,2,DEM,Marshall,"A104 South
-Marshall",124
-Chris Freeland,State Representative,6,REP,Marshall,"A104 South
-Marshall",318
-Linda Story Edwards,State Representative,6,DEM,Marshall,"A104 South
-Marshall",142
+James R Comer,U.S. House,1,REP,Marshall,"A104 South Marshall",310
+Paul Walker,U.S. House,1,DEM,Marshall,"A104 South Marshall",139
+Danny Carroll,State Senate,2,REP,Marshall,"A104 South Marshall",336
+Julie Tennyson,State Senate,2,DEM,Marshall,"A104 South Marshall",124
+Chris Freeland,State Representative,6,REP,Marshall,"A104 South Marshall",318
+Linda Story Edwards,State Representative,6,DEM,Marshall,"A104 South Marshall",142
 James R Comer,U.S. House,1,REP,Marshall,A105 Hardin,275
 Paul Walker,U.S. House,1,DEM,Marshall,A105 Hardin,183
 Danny Carroll,State Senate,2,REP,Marshall,A105 Hardin,291
@@ -59,18 +47,12 @@ Danny Carroll,State Senate,2,REP,Marshall,A106 Brewers,251
 Julie Tennyson,State Senate,2,DEM,Marshall,A106 Brewers,122
 Chris Freeland,State Representative,6,REP,Marshall,A106 Brewers,239
 Linda Story Edwards,State Representative,6,DEM,Marshall,A106 Brewers,132
-James R Comer,U.S. House,1,REP,Marshall,"A107 Southwest
-Benton",598
-Paul Walker,U.S. House,1,DEM,Marshall,"A107 Southwest
-Benton",286
-Danny Carroll,State Senate,2,REP,Marshall,"A107 Southwest
-Benton",588
-Julie Tennyson,State Senate,2,DEM,Marshall,"A107 Southwest
-Benton",299
-Chris Freeland,State Representative,6,REP,Marshall,"A107 Southwest
-Benton",585
-Linda Story Edwards,State Representative,6,DEM,Marshall,"A107 Southwest
-Benton",313
+James R Comer,U.S. House,1,REP,Marshall,"A107 Southwest Benton",598
+Paul Walker,U.S. House,1,DEM,Marshall,"A107 Southwest Benton",286
+Danny Carroll,State Senate,2,REP,Marshall,"A107 Southwest Benton",588
+Julie Tennyson,State Senate,2,DEM,Marshall,"A107 Southwest Benton",299
+Chris Freeland,State Representative,6,REP,Marshall,"A107 Southwest Benton",585
+Linda Story Edwards,State Representative,6,DEM,Marshall,"A107 Southwest Benton",313
 James R Comer,U.S. House,1,REP,Marshall,A108 Harvey,357
 Paul Walker,U.S. House,1,DEM,Marshall,A108 Harvey,122
 Danny Carroll,State Senate,2,REP,Marshall,A108 Harvey,338
@@ -101,42 +83,24 @@ Danny Carroll,State Senate,2,REP,Marshall,B104 North Benton,216
 Julie Tennyson,State Senate,2,DEM,Marshall,B104 North Benton,111
 Chris Freeland,State Representative,6,REP,Marshall,B104 North Benton,198
 Linda Story Edwards,State Representative,6,DEM,Marshall,B104 North Benton,130
-James R Comer,U.S. House,1,REP,Marshall,"B105 West
-Marshall",494
-Paul Walker,U.S. House,1,DEM,Marshall,"B105 West
-Marshall",201
-Danny Carroll,State Senate,2,REP,Marshall,"B105 West
-Marshall",482
-Julie Tennyson,State Senate,2,DEM,Marshall,"B105 West
-Marshall",222
-Chris Freeland,State Representative,6,REP,Marshall,"B105 West
-Marshall",467
-Linda Story Edwards,State Representative,6,DEM,Marshall,"B105 West
-Marshall",233
-James R Comer,U.S. House,1,REP,Marshall,"B106 East
-Marshall",522
-Paul Walker,U.S. House,1,DEM,Marshall,"B106 East
-Marshall",172
-Danny Carroll,State Senate,2,REP,Marshall,"B106 East
-Marshall",504
-Julie Tennyson,State Senate,2,DEM,Marshall,"B106 East
-Marshall",191
-Chris Freeland,State Representative,6,REP,Marshall,"B106 East
-Marshall",496
-Linda Story Edwards,State Representative,6,DEM,Marshall,"B106 East
-Marshall",198
-James R Comer,U.S. House,1,REP,Marshall,"B107 Birmingha
-m",413
-Paul Walker,U.S. House,1,DEM,Marshall,"B107 Birmingha
-m",195
-Danny Carroll,State Senate,2,REP,Marshall,"B107 Birmingha
-m",408
-Julie Tennyson,State Senate,2,DEM,Marshall,"B107 Birmingha
-m",210
-Chris Freeland,State Representative,6,REP,Marshall,"B107 Birmingha
-m",406
-Linda Story Edwards,State Representative,6,DEM,Marshall,"B107 Birmingha
-m",218
+James R Comer,U.S. House,1,REP,Marshall,"B105 West Marshall",494
+Paul Walker,U.S. House,1,DEM,Marshall,"B105 West Marshall",201
+Danny Carroll,State Senate,2,REP,Marshall,"B105 West Marshall",482
+Julie Tennyson,State Senate,2,DEM,Marshall,"B105 West Marshall",222
+Chris Freeland,State Representative,6,REP,Marshall,"B105 West Marshall",467
+Linda Story Edwards,State Representative,6,DEM,Marshall,"B105 West Marshall",233
+James R Comer,U.S. House,1,REP,Marshall,"B106 East Marshall",522
+Paul Walker,U.S. House,1,DEM,Marshall,"B106 East Marshall",172
+Danny Carroll,State Senate,2,REP,Marshall,"B106 East Marshall",504
+Julie Tennyson,State Senate,2,DEM,Marshall,"B106 East Marshall",191
+Chris Freeland,State Representative,6,REP,Marshall,"B106 East Marshall",496
+Linda Story Edwards,State Representative,6,DEM,Marshall,"B106 East Marshall",198
+James R Comer,U.S. House,1,REP,Marshall,"B107 Birmingham",413
+Paul Walker,U.S. House,1,DEM,Marshall,"B107 Birmingham",195
+Danny Carroll,State Senate,2,REP,Marshall,"B107 Birmingham",408
+Julie Tennyson,State Senate,2,DEM,Marshall,"B107 Birmingham",210
+Chris Freeland,State Representative,6,REP,Marshall,"B107 Birmingham",406
+Linda Story Edwards,State Representative,6,DEM,Marshall,"B107 Birmingham",218
 James R Comer,U.S. House,1,REP,Marshall,B108 Fairdealing,283
 Paul Walker,U.S. House,1,DEM,Marshall,B108 Fairdealing,125
 Danny Carroll,State Senate,2,REP,Marshall,B108 Fairdealing,270
@@ -149,42 +113,24 @@ Danny Carroll,State Senate,2,REP,Marshall,B109 Tatumsville,283
 Julie Tennyson,State Senate,2,DEM,Marshall,B109 Tatumsville,149
 Chris Freeland,State Representative,6,REP,Marshall,B109 Tatumsville,282
 Linda Story Edwards,State Representative,6,DEM,Marshall,B109 Tatumsville,150
-James R Comer,U.S. House,1,REP,Marshall,"C101 Little
-Cypress",485
-Paul Walker,U.S. House,1,DEM,Marshall,"C101 Little
-Cypress",204
-Danny Carroll,State Senate,2,REP,Marshall,"C101 Little
-Cypress",450
-Julie Tennyson,State Senate,2,DEM,Marshall,"C101 Little
-Cypress",244
-Chris Freeland,State Representative,6,REP,Marshall,"C101 Little
-Cypress",440
-Linda Story Edwards,State Representative,6,DEM,Marshall,"C101 Little
-Cypress",249
-James R Comer,U.S. House,1,REP,Marshall,"C102 East
-Calvert",239
-Paul Walker,U.S. House,1,DEM,Marshall,"C102 East
-Calvert",94
-Danny Carroll,State Senate,2,REP,Marshall,"C102 East
-Calvert",236
-Julie Tennyson,State Senate,2,DEM,Marshall,"C102 East
-Calvert",100
-Chris Freeland,State Representative,6,REP,Marshall,"C102 East
-Calvert",244
-Linda Story Edwards,State Representative,6,DEM,Marshall,"C102 East
-Calvert",95
-James R Comer,U.S. House,1,REP,Marshall,"C103 West
-Calvert",386
-Paul Walker,U.S. House,1,DEM,Marshall,"C103 West
-Calvert",211
-Danny Carroll,State Senate,2,REP,Marshall,"C103 West
-Calvert",390
-Julie Tennyson,State Senate,2,DEM,Marshall,"C103 West
-Calvert",212
-Chris Freeland,State Representative,6,REP,Marshall,"C103 West
-Calvert",372
-Linda Story Edwards,State Representative,6,DEM,Marshall,"C103 West
-Calvert",226
+James R Comer,U.S. House,1,REP,Marshall,"C101 Little Cypress",485
+Paul Walker,U.S. House,1,DEM,Marshall,"C101 Little Cypress",204
+Danny Carroll,State Senate,2,REP,Marshall,"C101 Little Cypress",450
+Julie Tennyson,State Senate,2,DEM,Marshall,"C101 Little Cypress",244
+Chris Freeland,State Representative,6,REP,Marshall,"C101 Little Cypress",440
+Linda Story Edwards,State Representative,6,DEM,Marshall,"C101 Little Cypress",249
+James R Comer,U.S. House,1,REP,Marshall,"C102 East Calvert",239
+Paul Walker,U.S. House,1,DEM,Marshall,"C102 East Calvert",94
+Danny Carroll,State Senate,2,REP,Marshall,"C102 East Calvert",236
+Julie Tennyson,State Senate,2,DEM,Marshall,"C102 East Calvert",100
+Chris Freeland,State Representative,6,REP,Marshall,"C102 East Calvert",244
+Linda Story Edwards,State Representative,6,DEM,Marshall,"C102 East Calvert",95
+James R Comer,U.S. House,1,REP,Marshall,"C103 West Calvert",386
+Paul Walker,U.S. House,1,DEM,Marshall,"C103 West Calvert",211
+Danny Carroll,State Senate,2,REP,Marshall,"C103 West Calvert",390
+Julie Tennyson,State Senate,2,DEM,Marshall,"C103 West Calvert",212
+Chris Freeland,State Representative,6,REP,Marshall,"C103 West Calvert",372
+Linda Story Edwards,State Representative,6,DEM,Marshall,"C103 West Calvert",226
 James R Comer,U.S. House,1,REP,Marshall,C104 Sharpe,715
 Paul Walker,U.S. House,1,DEM,Marshall,C104 Sharpe,271
 Danny Carroll,State Senate,2,REP,Marshall,C104 Sharpe,679
@@ -197,33 +143,21 @@ Danny Carroll,State Senate,2,REP,Marshall,C105 Palma,447
 Julie Tennyson,State Senate,2,DEM,Marshall,C105 Palma,278
 Chris Freeland,State Representative,6,REP,Marshall,C105 Palma,433
 Linda Story Edwards,State Representative,6,DEM,Marshall,C105 Palma,293
-James R Comer,U.S. House,1,REP,Marshall,"C106 West
-Gilbertsville",264
-Paul Walker,U.S. House,1,DEM,Marshall,"C106 West
-Gilbertsville",109
-Danny Carroll,State Senate,2,REP,Marshall,"C106 West
-Gilbertsville",259
-Julie Tennyson,State Senate,2,DEM,Marshall,"C106 West
-Gilbertsville",117
-Chris Freeland,State Representative,6,REP,Marshall,"C106 West
-Gilbertsville",261
-Linda Story Edwards,State Representative,6,DEM,Marshall,"C106 West
-Gilbertsville",115
+James R Comer,U.S. House,1,REP,Marshall,"C106 West Gilbertsville",264
+Paul Walker,U.S. House,1,DEM,Marshall,"C106 West Gilbertsville",109
+Danny Carroll,State Senate,2,REP,Marshall,"C106 West Gilbertsville",259
+Julie Tennyson,State Senate,2,DEM,Marshall,"C106 West Gilbertsville",117
+Chris Freeland,State Representative,6,REP,Marshall,"C106 West Gilbertsville",261
+Linda Story Edwards,State Representative,6,DEM,Marshall,"C106 West Gilbertsville",115
 James R Comer,U.S. House,1,REP,Marshall,C107 Gilbertsville,182
 Paul Walker,U.S. House,1,DEM,Marshall,C107 Gilbertsville,72
 Danny Carroll,State Senate,2,REP,Marshall,C107 Gilbertsville,188
 Julie Tennyson,State Senate,2,DEM,Marshall,C107 Gilbertsville,69
 Chris Freeland,State Representative,6,REP,Marshall,C107 Gilbertsville,168
 Linda Story Edwards,State Representative,6,DEM,Marshall,C107 Gilbertsville,91
-James R Comer,U.S. House,1,REP,Marshall,"C108 Central
-Calvert",250
-Paul Walker,U.S. House,1,DEM,Marshall,"C108 Central
-Calvert",171
-Danny Carroll,State Senate,2,REP,Marshall,"C108 Central
-Calvert",252
-Julie Tennyson,State Senate,2,DEM,Marshall,"C108 Central
-Calvert",171
-Chris Freeland,State Representative,6,REP,Marshall,"C108 Central
-Calvert",237
-Linda Story Edwards,State Representative,6,DEM,Marshall,"C108 Central
-Calvert",183
+James R Comer,U.S. House,1,REP,Marshall,"C108 Central Calvert",250
+Paul Walker,U.S. House,1,DEM,Marshall,"C108 Central Calvert",171
+Danny Carroll,State Senate,2,REP,Marshall,"C108 Central Calvert",252
+Julie Tennyson,State Senate,2,DEM,Marshall,"C108 Central Calvert",171
+Chris Freeland,State Representative,6,REP,Marshall,"C108 Central Calvert",237
+Linda Story Edwards,State Representative,6,DEM,Marshall,"C108 Central Calvert",183


### PR DESCRIPTION
This removes newline characters that appeared in the middle of quoted entries.