### PR TITLE
Update format tests

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v0.1.0
+        ref: v1.0.0
         path: format_tests
 
     - name: Run format tests


### PR DESCRIPTION
This updates the format tests to version [1.0.0](https://github.com/openelections/openelections-format-tests/releases/tag/v1.0.0).  The tests now verify that the "votes" column contains values that represent integers.  This reveals the following errors:

* 2018/20181106__ky__general__county.csv
  ```
  * There are 1 rows with votes that aren't integers:

  	Headers: ['county', 'office', 'district', 'candidate', 'party', 'votes']:
  	Row 112: ['Mercer', 'U.S. House', '2', 'Hank Linderman', 'DEM', '2.4130000000000003']
  ```