### PR TITLE
Fix parsing error that resulted in non-integer votes

### DIFF
--- a/2018/20181106__ky__general__county.csv
+++ b/2018/20181106__ky__general__county.csv
@@ -109,7 +109,7 @@ Hart,U.S. House,2,Hank Linderman,DEM,1745.0
 Jessamine,U.S. House,2,Hank Linderman,DEM,1529.0
 Larue,U.S. House,2,Hank Linderman,DEM,1178.0
 Meade,U.S. House,2,Hank Linderman,DEM,3189.0
-Mercer,U.S. House,2,Hank Linderman,DEM,2.4130000000000003
+Mercer,U.S. House,2,Hank Linderman,DEM,2413
 Nelson,U.S. House,2,Hank Linderman,DEM,5617.0
 Spencer,U.S. House,2,Hank Linderman,DEM,540.0
 Warren,U.S. House,2,Hank Linderman,DEM,13935.0


### PR DESCRIPTION
According to the [official document](https://elect.ky.gov/results/2010-2019/Documents/2018GeneralElectionCertified.pdf), Hank Linderman received 2,413 votes.

![image](https://user-images.githubusercontent.com/17345532/129072286-fffa895d-cc38-4b94-bc27-a15a7573113b.png)
