### PR TITLE
Add workflow to run data tests

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -1,0 +1,31 @@
+name: Data Tests
+
+on: [push, pull_request]
+
+jobs:
+  duplicate_entries:
+    name: Duplicate entries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Check out data
+      uses: actions/checkout@v2.3.4
+      with:
+        path: data
+
+    - name: Check out data tests
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: openelections/openelections-data-tests
+        ref: v0.1.1
+        path: data_tests
+
+    - name: Run data tests
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py duplicate_entries ${{ github.workspace }}/data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/openelections/openelections-data-ky/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ky/actions)
-[![Build Status](https://github.com/openelections/openelections-data-ky/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ky/actions)
+[![Build Status](https://github.com/openelections/openelections-data-ky/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ky/actions/workflows/data_tests.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/openelections/openelections-data-ky/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ky/actions/workflows/format_tests.yml?query=branch%3Amaster)
 
 # openelections-data-ky
 Pre-processed results for Kentucky elections

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# openelections-data-ky [![Build Status](https://github.com/openelections/openelections-data-ky/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ky/actions)
+[![Build Status](https://github.com/openelections/openelections-data-ky/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ky/actions)
+[![Build Status](https://github.com/openelections/openelections-data-ky/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ky/actions)
+
+# openelections-data-ky
 Pre-processed results for Kentucky elections
 
 Almost all of the results here are converted from PDFs, mostly posted by the [State Board of Elections](https://elect.ky.gov/results/2010-2019/Pages/default.aspx). Many of these files are marked or labeled as unofficial, but in checking with county clerks we've found that they in fact represent official results. Some counties post their own precinct results and a few use Clarity Elections software to post results (the state also uses Clarity for [unofficial election night results](https://results.enr.clarityelections.com/KY/)).


### PR DESCRIPTION
This adds a workflow to run the [data validation](https://github.com/openelections/openelections-data-tests) tests. This currently consists of a single job that checks for duplicate entries in the data files.